### PR TITLE
check for request method before formatting game_name

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -34,13 +34,16 @@ class LogSerializer(serializers.ModelSerializer):
         model = models.Log
         fields = '__all__'
 
-
+    # used for formatting time from  2024-04-19 21:00:00+00:00 to 2024-04-19 21:00
     def to_representation(self, instance):
         representation = super().to_representation(instance)
-        if 'game_name' in representation and representation['game_name']:
-            pattern = r'(\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}):\d{2}\+\d{2}(.+)'
-            formatted_str = re.sub(pattern, r'\1\2', representation['game_name'])
-            representation['game_name'] = formatted_str
+        # we check for request method since game_name is only included in responses of get requests
+        if self.context.get('request') and self.context['request'].method == 'GET':
+            if 'game_name' in representation and representation['game_name']:
+                pattern = r'(\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}):\d{2}\+\d{2}(.+)'
+                formatted_str = re.sub(pattern, r'\1\2', representation['game_name'])
+                representation['game_name'] = formatted_str
+                print("used it")
         return representation
 
 class EventSerializer(serializers.ModelSerializer):

--- a/backend/api/views/other_views.py
+++ b/backend/api/views/other_views.py
@@ -235,8 +235,11 @@ class LogViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
 
+        #adds event name to object
         queryset = models.Log.objects.select_related('game_id').annotate(event_name=F('game_id__event_id__name'))
-
+        
+        #adds game name to object like "2024-04-19 14:10 Berlin United vs Bembelbots half2"
+        # since I can't format the string here correctly I had to overload the to_representation function in LogSerializer
         queryset = queryset.select_related('game_id').annotate(game_name=functions.Concat(
         'game_id__start_time', Value(' '),
         'game_id__team1', Value(' vs '),


### PR DESCRIPTION
There was a bug that the to representation function in LogSerializer tried to format game_name on other requests than GET.
Now we check for the request method before attempting to access game_name.

The to_representation method formats game_name strings from 
2024-04-19 14:10:00+00 Berlin United vs Bembelbots half2
to
2024-04-19 14:10 Berlin United vs Bembelbots half2