### PR TITLE
set grammatically correct plural of log status

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -90,6 +90,9 @@ class LogStatus(models.Model):
     num_bottom = models.IntegerField(blank=True, null=True)
     num_top = models.IntegerField(blank=True, null=True)
 
+    class Meta:
+        verbose_name_plural = "Log status"
+
 
 class Image(models.Model):
     class Camera(models.TextChoices):


### PR DESCRIPTION
Django thought that the plural of log status was log_statuss

Now I explicitly set the correct plural. 

This changes how log status is displayed in list of object from 
![image](https://github.com/user-attachments/assets/18ec6598-142c-424b-b0ac-9da6d23efd50)
to
![image](https://github.com/user-attachments/assets/48cfb73b-a3c2-41de-820a-055278683874)

